### PR TITLE
Add ability to output details about hosts

### DIFF
--- a/hostlist/buildfiles.py
+++ b/hostlist/buildfiles.py
@@ -39,6 +39,9 @@ def parse_args(services):
                         '-d',
                         action='store_true',
                         help='only parse, don\'t sync')
+    parser.add_argument('filter',
+                        nargs='*',
+                        help='''Print hosts matching a given filter. This can be hostnames or groupnames.''')
 
     for service in services:
         parser.add_argument('--' + service,
@@ -132,7 +135,7 @@ def main():
     if args.verbose >= 1:
         logging.getLogger().setLevel(logging.DEBUG)
     if args.quiet:
-        logging.getLogger().setLevel(logging.CRITICAL)
+        logging.getLogger().setLevel(logging.ERROR)
 
     if not Config.load():
         logging.error("Need %s file to run." % Config.CONFIGNAME)
@@ -144,6 +147,10 @@ def main():
     file_cnames = cnamelist.FileCNamelist()
 
     file_hostlist.check_consistency(file_cnames)
+
+    if args.filter:
+        file_hostlist.print(args.filter)
+        sys.exit(0)
 
     if activeservices:
         run_service(activeservices.pop(), file_hostlist, file_cnames)

--- a/hostlist/host.py
+++ b/hostlist/host.py
@@ -63,13 +63,27 @@ class Host:
     def __str__(self):
         return self.output(delim='\t')
 
-    def output(self, delim='\n', printmac=False):
+    def output(self,
+               delim='\n',
+               printmac=False,
+               printgroups=False,
+               printallvars=False,
+               printvars=[]):
+
         infos = [
             ("Hostname: ", self.fqdn),
             ("IP: ", str(self.ip) + " (nonunique)" if not self.vars['unique'] else self.ip),
         ]
         if printmac:
             infos.append(("MAC: ", self.mac))
+
+        if printallvars:
+            printvars = self.vars.keys()
+        for var in printvars:
+            infos.append((var + ': ', self.vars.get(var)))
+
+        if printgroups:
+            infos.append(('Groups: ', ', '.join(self.groups)))
 
         out = []
         for a, b in infos:
@@ -180,6 +194,10 @@ class YMLHost(Host):
         if self.ip < iprange[0] or self.ip > iprange[1]:
             raise Exception("%s has IP %s outside of range %s-%s." %
                             (self.fqdn, self.ip, iprange[0], iprange[1]))
+
+    def filter(self, filter):
+        assert filter.__class__ == list
+        return self.hostname in filter or any([g in filter for g in self.groups])
 
 
 class MAC(str):

--- a/hostlist/hostlist.py
+++ b/hostlist/hostlist.py
@@ -218,6 +218,16 @@ class YMLHostlist(Hostlist):
                     str(h.ip) + ':' + port for port in h.vars['docker']['ports']
                 ]
 
+    def print(self, filter):
+        filtered = [h for h in self if h.filter(filter)]
+        for h in filtered:
+            if logging.getLogger().level == logging.DEBUG:
+                print(h.output(printgroups=True, printallvars=True))
+            elif logging.getLogger().level == logging.INFO:
+                print(h.output(delim='\t', printgroups=True))
+            else:
+                print(h.hostname)
+
     def check_iprange_overlap(self):
         "check whether any of the ipranges given in headers overlap"
 


### PR DESCRIPTION
Output list of hosts based on groups/hostnames.

Can run `buildfiles my.host.name` or `buildfiles autosuspend` to get a list of matching hosts.
With `-q` it's only hostnames. Otherwise also with groupnames. Additional details are available via `-v` and `-vv` (all vairables and parsing info).