### PR TITLE
Use groups for need_* and outputs

### DIFF
--- a/hostlist/host.py
+++ b/hostlist/host.py
@@ -24,8 +24,6 @@ class Host:
 
     def _set_defaults(self):
         self.vars = {
-            'needs_mac': True,
-            'needs_ip': True,
             'unique': True,
         }
 
@@ -106,7 +104,7 @@ class YMLHost(Host):
     "Host generated from yml file entry"
 
     _num = '(2[0-5]|1[0-9]|[0-9])?[0-9]'
-    IPREGEXP = re.compile(r'^(' + _num + '\.){3}(' + _num + ')$')
+    IPREGEXP = re.compile(r'^(' + _num + r'\.){3}(' + _num + ')$')
     MACREGEXP = re.compile(r'^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$')
 
     def __init__(self, inputdata, hosttype, institute, header=None):
@@ -117,12 +115,13 @@ class YMLHost(Host):
         self._set_defaults()
         self.vars['hosttype'] = hosttype
         self.vars['institute'] = institute
-        self.groups = set()
+        self.groups = set(Config.get('groups', []))
 
         if header:
             for var, value in header.items():
                 self.vars[var] = value
             self.groups.update(header.get('groups', {}))
+            self.groups.difference_update(header.get('notgroups', {}))
 
         for var, value in inputdata.items():
             self.vars[var] = value

--- a/hostlist/hostlist.py
+++ b/hostlist/hostlist.py
@@ -216,14 +216,14 @@ class YMLHostlist(Hostlist):
 
         success = True
         for h in self:
-            if 'needs_ip' in h.vars and h.vars['needs_ip'] and h.ip is None:
-                logging.error("Missing IP in %s " % h)
+            if ('needs_ip' in h.groups or ('needs_ip' in h.vars and h.vars['needs_ip'])) and h.ip is None:
+                logging.error("Missing IP in %s ", h)
                 success = False
 
         if isinstance(self, YMLHostlist):
             for h in self:
-                if h.vars['needs_mac'] and h.mac is None:
-                    logging.error("Missing MAC in %s " % h)
+                if ('needs_mac' in h.groups or ('needs_mac' in h.vars and h.vars['needs_mac'])) and h.mac is None:
+                    logging.error("Missing MAC in %s ", h)
                     success = False
         return success
 

--- a/hostlist/output_services.py
+++ b/hostlist/output_services.py
@@ -12,7 +12,11 @@ class Ssh_Known_HostsOutput:
     @classmethod
     def gen_content(cls, hostlist, cnames):
         # only scan keys on hosts that are in ansible
-        scan_hosts = [h for h in hostlist if h.vars.get('gen_ssh_known_hosts', False)]
+        scan_hosts = [
+            h for h in hostlist
+            if h.vars.get('gen_ssh_known_hosts', False) or
+            'ssh_known_hosts' in h.groups
+        ]
         aliases = [alias
                    for host in scan_hosts
                    for alias in host.aliases
@@ -42,7 +46,11 @@ class MuninOutput:
 
     @classmethod
     def gen_content(cls, hostlist, cnames):
-        hostnames = (h for h in hostlist if h.vars.get('gen_munin', False))
+        hostnames = (
+            h for h in hostlist
+            if h.vars.get('gen_munin', False) or
+            'muninnode' in h.groups
+        )
         fcont = ''
         for host in hostnames:
             fcont += cls._get_hostblock(host)
@@ -115,7 +123,7 @@ class AnsibleOutput:
         docker_services = {}
         for host in hostlist:
             # online add hosts that have ansible=yes
-            if 'ansible' in host.vars and not host.vars['ansible']:
+            if 'ansible' not in host.groups and ('ansible' in host.vars and not host.vars['ansible']):
                 continue
             ans = cls._gen_host_content(host)
             hostvars[ans['fqdn']] = ans['vars']

--- a/tests/hostlists/desktops-abc.yml
+++ b/tests/hostlists/desktops-abc.yml
@@ -19,4 +19,5 @@ hosts:
   - hostname: host5.abc.example.com
     mac: 00:12:34:ab:CD:F1
     ip: 198.51.100.5
-    gen_munin: True
+    groups:
+      - muninnode

--- a/tests/hostlists/server.yml
+++ b/tests/hostlists/server.yml
@@ -9,7 +9,8 @@ hosts:
     institute: blubberinst
     groups:
       - superserver
-    needs_mac: False
+    not_groups:
+      - needs_mac
   - hostname: serv2.abc.example.com
     institute: extinst
     ip: 203.0.113.2
@@ -21,5 +22,6 @@ header:
 hosts:
   - hostname: serv3
     ip: 198.51.100.101
-    needs_mac: False
+    not_groups:
+      - needs_mac
     institute: abc


### PR DESCRIPTION
Instead of hardcoding some vars for outputs/checks, make those "groups"
that use the normal group parsing/inheritance. Allow default groups in
config.

Fixes #7 